### PR TITLE
setup firestore emulator locally and get rid of isTestNumber check

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,27 @@ Note that we are using the Ant design component library. Information on theme cu
 - https://ant.design/docs/react/use-with-create-react-app#Customize-Theme
 - https://ant.design/docs/react/customize-theme
 
-### Running the app locally
+### Running the frontend app locally
 
-```
+This will run the app against local Firebase emulators (see instructions below).
+
+```bash
 cd app
-yarn start
+yarn start # or `yarn staging-dev` to run against the Firestore in staging
+```
+
+#### Running the backend (Firestore emulator) locally
+
+```bash
+cd functions
+yarn serve
+```
+
+There's also a way to grab runtime configuration options from staging, though it's not strictly required to run the
+backend, this is just required for external services.
+
+```bash
+firebase functions:config:get > functions/.runtimeconfig.json
 ```
 
 Accessing Mac localhost on iPhone

--- a/app/package.json
+++ b/app/package.json
@@ -18,6 +18,7 @@
     "uuid": "^8.2.0"
   },
   "scripts": {
+    "staging-dev": "REACT_APP_STAGING_DEV=1 craco start",
     "start": "craco start",
     "build": "craco build",
     "test": "craco test",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -42,6 +42,10 @@ const firebaseConfig = process.env.PUBLIC_URL.startsWith("https://storydating.co
 firebase.initializeApp(firebaseConfig);
 
 function App() {
+  if (process.env.NODE_ENV === "development" && !process.env.REACT_APP_STAGING_DEV) {
+    firebase.functions().useEmulator("localhost", 5001);
+    firebase.auth().useEmulator("http://localhost:9099");
+  }
   firebase.remoteConfig().fetchAndActivate();
   firebase.analytics();
 

--- a/firebase.json
+++ b/firebase.json
@@ -8,7 +8,11 @@
   },
   "hosting": {
     "public": "app/build",
-    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
     "redirects": [
       {
         "source": "/signup",
@@ -27,5 +31,28 @@
         "destination": "/index.html"
       }
     ]
+  },
+  "emulators": {
+    "auth": {
+      "port": 9099
+    },
+    "functions": {
+      "port": 5001
+    },
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": true
+    },
+    "database": {
+      "port": 9000
+    },
+    "pubsub": {
+      "port": 8085
+    },
+    "hosting": {
+      "port": 5000
+    }
   }
 }

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -5,3 +5,5 @@ lib/
 typings/
 
 node_modules/
+
+.runtimeconfig

--- a/functions/.runtimeconfig.json
+++ b/functions/.runtimeconfig.json
@@ -1,5 +1,0 @@
-{
-  "twilio": {
-    "auth_token": "token"
-  }
-}

--- a/functions/package.json
+++ b/functions/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "lint": "tslint --project tsconfig.json",
     "build": "tsc",
-    "serve": "npm run build && npx firebase emulators:start --only functions",
+    "serve": "npm run build && npx firebase emulators:start",
     "shell": "npm run build && npx firebase functions:shell",
     "start": "npm run shell",
     "deploy": "npx firebase deploy --only functions",

--- a/functions/test/twilio.test.ts
+++ b/functions/test/twilio.test.ts
@@ -1,9 +1,10 @@
 import * as test from "firebase-functions-test";
+// WARNING: this must come first or else imported modules may not see this config value on load
+test().mockConfig({ twilio: { auth_token: "token" } });
 import * as uuid from "uuid";
 import { IMatch } from "../src/firestore";
 import { callStudio, getNextDays, saveRevealHelper, TWILIO_NUMBER } from "../src/twilio";
 import { firestore, match, user } from "./mock";
-test().mockConfig({ twilio: { auth_token: "token" } });
 
 const mockCreate = jest.fn();
 jest.mock("twilio", () => {

--- a/functions/test/typeform.test.ts
+++ b/functions/test/typeform.test.ts
@@ -1,7 +1,8 @@
 import * as test from "firebase-functions-test";
+// WARNING: this must come first or else imported modules may not see this config value on load
+test().mockConfig({ twilio: { auth_token: "token" } });
 import * as moment from "moment-timezone";
 import { parseAvailability } from "../src/typeform";
-test().mockConfig({ twilio: { auth_token: "token" } });
 
 const getTimestamp = () => moment("2021-03-10");
 


### PR DESCRIPTION
this allows the app to run totally off the online firestore servers, i didn't test if it works without a network connection at all, but it
might. this also gets rid of the isTestNumber check that you talked about, sorry for combining them into the same commit, i can split them apart if you'd prefer that.

in addition to the functions running locally, the datastores do as well. note that your local database would **get trashed every time you shut off the emulator**. so far that hasn't been a problem for me, though we could optionally persist data via command line flags: https://firebase.google.com/docs/emulator-suite/install_and_configure#export_and_import_emulator_data

### verifying sms with firestore emulator
![image](https://user-images.githubusercontent.com/18086/114255150-6c722300-9968-11eb-84ab-9b25bf9ebe5b.png)

### error reporting
![image](https://user-images.githubusercontent.com/18086/114255153-7431c780-9968-11eb-82d5-5b1ca734accd.png)

the `console.error` code looks right, but it showed up in the dev console as an `I` warning line instead of an `E`. we may have to deploy to staging for a reliable test.

---

i'll go through and annotate the code review below explaining in more detail the changes i made.