### PR TITLE
go back to using antd Image for profile pic

### DIFF
--- a/app/src/profile/ProfileCard.css
+++ b/app/src/profile/ProfileCard.css
@@ -22,12 +22,16 @@
   justify-content: center;
 }
 
+.profile-photo-container .ant-image {
+  width: 100%;
+  height: 100%;
+}
+
 .profile-photo {
   width: 100%;
   height: 100%;
   padding: 0;
-  background-position: center;
-  background-size: cover;
+  object-fit: cover;
 }
 
 .profile-photo-placeholder {

--- a/app/src/profile/ProfileCard.tsx
+++ b/app/src/profile/ProfileCard.tsx
@@ -1,4 +1,5 @@
 import { UserOutlined } from "@ant-design/icons";
+import { Image } from "antd";
 import React, { FunctionComponent } from "react";
 import "./ProfileCard.css";
 
@@ -11,12 +12,14 @@ interface ProfileCardProps {
 }
 
 const ProfileCard: FunctionComponent<ProfileCardProps> = (props) => {
+  // use the antd Image component to allow enlarging the photo on click
   return (
     <div className="profile-card">
       <div className="profile-card-top">
         <div className="profile-photo-container">
-          {props.photoUrl && <div
-            style={{backgroundImage: `url(${props.photoUrl})`}}
+          {props.photoUrl && <Image
+            src={props.photoUrl}
+            preview={{ mask: "" }}
             className="profile-photo"
           />}
           {!props.uploading && !props.photoUrl && <UserOutlined className="profile-photo-placeholder" />}


### PR DESCRIPTION
I missed that we stopped using the `Image` component in #159 which allows enlarging the photo on click!

And we do need to set the `mask` prop, otherwise there's default "Preview" text when you hover over the photo.

tested this on square, landscape and portrait photos 👍 