### PR TITLE
export a user's twilio data and upload to storage

### DIFF
--- a/functions/scripts/exportTwilioData.js
+++ b/functions/scripts/exportTwilioData.js
@@ -1,0 +1,54 @@
+const admin = require("firebase-admin");
+const util = require("./util");
+const twilio = require("twilio");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const BUCKET = "speakeasy-prod.appspot.com";
+
+// dir is either 'to' or 'from'
+async function saveMessages(id, phone, dir, filename) {
+  const messages = await client.messages.list({ [dir]: phone });
+  messages.forEach(msg => {
+    // replace the user phone with the user ID
+    msg[dir] = userId;
+  });
+  const filePath = path.join(os.tmpdir(), filename)
+  console.log("writing to temp file " + filePath);
+  fs.writeFileSync(filePath, JSON.stringify(messages));
+  await admin.storage().bucket(BUCKET).upload(filePath, { destination: `twilio/${id}/${filename}` });
+}
+
+async function saveCalls(id, phone, dir, filename) {
+  const calls = await client.calls.list({ [dir]: phone });
+  calls.forEach(call => {
+    call[dir] = userId;
+    call[dir + "Formatted"] = userId;
+  });
+  const filePath = path.join(os.tmpdir(), filename)
+  console.log("writing to temp file " + filePath);
+  fs.writeFileSync(filePath, JSON.stringify(calls));
+  await admin.storage().bucket(BUCKET).upload(filePath, { destination: `twilio/${id}/${filename}` });
+}
+
+util.checkRequiredEnvVars(["GOOGLE_APPLICATION_CREDENTIALS", "TWILIO_AUTH_TOKEN", "USER_ID"]);
+const client = twilio("AC07d4a9a61ac7c91f7e5cecf1e27c45a6", process.env.TWILIO_AUTH_TOKEN);
+
+admin.initializeApp();
+
+const userId = process.env.USER_ID;
+admin
+  .firestore()
+  .collection("users")
+  .doc(userId)
+  .get()
+  .then(async (doc) => {
+    const phone = doc.get("phone");
+
+    saveMessages(userId, phone, 'to', "messages_to.json")
+    saveMessages(userId, phone, 'from', "messages_from.json")
+
+    saveCalls(userId, phone, 'to', "calls_to.json")
+    saveCalls(userId, phone, 'from', "calls_from.json")
+  });


### PR DESCRIPTION
Received an account deletion request. We want to preserve info about location, fun facts, interests, etc as well as text and match history, but delete all identifying info such as name, phone, email.

This PR:
1. exports user call and text data from Twilio (which we don't currently keep a rescord of ourselves in Firestore/another data store)
2. replaces the phone number in the twilio data with the user ID
3. creates a folder `twilio/{userId}` in Google Cloud Storage and uploads 4 files: `calls_from.json`, `calls_to.json`, `messages_from.json`, `messages_to.json`

In order to complete the deletion request, the first/last names, phone and email will need to be removed manually from the `users` document in Firestore.