### PR TITLE
only show photo after 20 minutes are up

### DIFF
--- a/functions/src/matches.ts
+++ b/functions/src/matches.ts
@@ -11,7 +11,7 @@ function createUpcomingMatchView(match: IMatch, viewingUser: IUser, otherUser: I
   const minutesSinceMatch = moment().diff(match.created_at.toDate(), "minutes");
   const requestReveal = connected
     // the call ended < 15 min ago
-    && minutesSinceMatch > 0 && minutesSinceMatch < 35
+    && minutesSinceMatch >= 20 && minutesSinceMatch < 35
     // the user hasn't responded yet to the reveal request
     && match.revealed[viewingUser.id] === undefined;
   return {


### PR DESCRIPTION
some users have told me they look up their matches while on the phone call =/ can't prevent people from looking up photos outside of our platform, but let's hide the photos until the 20 min call is over.